### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/codetheuri/Tusk/security/code-scanning/1](https://github.com/codetheuri/Tusk/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access to any resources, we can set the permissions to `contents: read`, which is the minimal privilege required for most workflows. This change should be applied at the root level of the workflow to cover all jobs, as none of the jobs in the workflow require elevated permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
