### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/app/handlers/todo.go
+++ b/internal/app/handlers/todo.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"math"
 
 	"github.com/codetheuri/todolist/internal/app/services"
 	appErrors "github.com/codetheuri/todolist/pkg/errors"
@@ -61,6 +62,12 @@ func (h *TodoHandler) GetTodoByID(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.log.Warn("Handler: Invalid ID format", "id", idStr, "error", err)
 		web.RespondError(w, appErrors.ValidationError("Invalid ID format", err, nil), http.StatusBadRequest)
+		return
+	}
+	// Check if the parsed ID is within the bounds of the uint type
+	if id > math.MaxUint {
+		h.log.Warn("Handler: ID exceeds the maximum allowed value for uint", "id", id)
+		web.RespondError(w, appErrors.ValidationError("ID exceeds the maximum allowed value", nil, nil), http.StatusBadRequest)
 		return
 	}
 	res, err := h.todoService.GetTodoByID(uint(id))


### PR DESCRIPTION
Potential fix for [https://github.com/codetheuri/Tusk/security/code-scanning/2](https://github.com/codetheuri/Tusk/security/code-scanning/2)

To fix the issue:
1. Add bounds checks before converting the `uint64` value (`id`) to the smaller `uint` type.
2. Use the `math` package to determine the maximum value for the `uint` type (`math.MaxUint32` for a 32-bit platform) and ensure the parsed value falls within this range.
3. If the value is out of bounds, return an appropriate error response to the client.

Changes will be made to the `GetTodoByID` function in the file `internal/app/handlers/todo.go`. Specifically:
- Add a bounds check after parsing `id` using `strconv.ParseUint`.
- Validate that the value is within the permissible range for the `uint` type before performing the conversion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
