### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/pkg/auth/token/interface.go
+++ b/pkg/auth/token/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 	"time"
-
+	"math"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -49,7 +49,9 @@ func GetUserIDFromContext(ctx context.Context)(uint, bool){
 	val:= ctx.Value(ContextKeyUserID)
 	if idStr, ok := val.(string); ok{
 		if id, err := strconv.ParseUint(idStr, 10,64); err == nil{
-			return uint(id), true
+			if id <= uint64(math.MaxUint) {
+				return uint(id), true
+			}
 		}
 	}
 	return 0, false


### PR DESCRIPTION
Potential fix for [https://github.com/codetheuri/Tusk/security/code-scanning/10](https://github.com/codetheuri/Tusk/security/code-scanning/10)

To fix the problem, we need to ensure that the value parsed from the string fits within the range of a `uint` before casting. The best way is to check that the parsed `id` is less than or equal to `math.MaxUint` (which is architecture-dependent), and only then perform the cast. If the value is out of bounds, return the zero value and `false` to indicate failure. This change should be made in the `GetUserIDFromContext` function in `pkg/auth/token/interface.go`. We will need to import the `math` package to access `math.MaxUint`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
