### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/internal/app/auth/handlers/handler.go
+++ b/internal/app/auth/handlers/handler.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/codetheuri/todolist/pkg/validators"
 	//"github.com/codetheuri/todolist/internal/app/modules/auth/models"
+	"math"
 )
 
 type AuthHandler interface {
@@ -177,6 +178,12 @@ func (h *authHandler) GetUserProfile(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.log.Warn("Handler: Invalid user ID format in URL", err, "id", userIDStr)
 		web.RespondError(w, appErrors.ValidationError("invalid user ID format", nil, nil), http.StatusBadRequest)
+		return
+	}
+	// Bounds check: ensure userID fits in uint
+	if userID > uint64(math.MaxUint) {
+		h.log.Warn("Handler: User ID out of range for uint", "id", userIDStr)
+		web.RespondError(w, appErrors.ValidationError("user ID out of range", nil, nil), http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/codetheuri/Tusk/security/code-scanning/7](https://github.com/codetheuri/Tusk/security/code-scanning/7)

To fix the problem, we need to ensure that the value parsed from the string (`userIDStr`) does not exceed the maximum value of the target type (`uint`). The best way to do this is to check that `userID` is less than or equal to `math.MaxUint` before performing the conversion. If the value is out of bounds, the handler should return an error response. This change should be made in the `GetUserProfile` handler, specifically after parsing `userID` and before converting it to `uint`. We need to import the `math` package to access `math.MaxUint`. The same pattern should be applied to any other location where this conversion occurs, but based on the provided snippet, only line 184 in `GetUserProfile` is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
